### PR TITLE
add fallback PCRE_NEVER_UTF for PCRE 8.32 and lower

### DIFF
--- a/pcre.go
+++ b/pcre.go
@@ -56,6 +56,7 @@ package pcre
 // #cgo pkg-config: libpcre
 // #include <pcre.h>
 // #include <string.h>
+// #include "./pcre_fallback.h"
 import "C"
 
 import (

--- a/pcre_fallback.h
+++ b/pcre_fallback.h
@@ -1,0 +1,3 @@
+#ifndef PCRE_NEVER_UTF
+#define PCRE_NEVER_UTF 0x0
+#endif


### PR DESCRIPTION
PCRE_NEVER_UTF was added in PCRE 8.33 and thus this library won't compile on
servers with a lower version. Ubuntu 12.04 and 14.04 both ship with this version
and are commonly used.

http://upstream.rosalinux.ru/compat_reports/pcre/8.32_to_8.33/abi_compat_report.html

http://packages.ubuntu.com/trusty/libpcre3